### PR TITLE
Fix RTC "Lost" status after restart by clearing OS bit

### DIFF
--- a/src/drivers/Pcf8523.cpp
+++ b/src/drivers/Pcf8523.cpp
@@ -94,3 +94,12 @@ bool Pcf8523::writeTime(const tm &utc_tm) {
     buf[6] = bin2bcd(static_cast<uint8_t>(utc_tm.tm_year + 1900 - 2000));
     return write(Config::PCF8523_REG_SECONDS, buf, sizeof(buf));
 }
+
+bool Pcf8523::clearOscillatorStop() {
+    uint8_t sec = 0;
+    if (!read(Config::PCF8523_REG_SECONDS, &sec, 1)) {
+        return false;
+    }
+    sec &= 0x7F;  // Clear OS bit (bit 7), keep seconds
+    return write(Config::PCF8523_REG_SECONDS, &sec, 1);
+}

--- a/src/drivers/Pcf8523.h
+++ b/src/drivers/Pcf8523.h
@@ -13,6 +13,7 @@ public:
     bool begin();
     bool readTime(tm &out, bool &osc_stop, bool &valid);
     bool writeTime(const tm &utc_tm);
+    bool clearOscillatorStop();
 
 private:
     static uint8_t bcd2bin(uint8_t val);

--- a/src/modules/TimeManager.cpp
+++ b/src/modules/TimeManager.cpp
@@ -53,16 +53,21 @@ bool TimeManager::initRtc() {
     }
     rtc_present_ = true;
     rtc_lost_power_ = osc_stop;
-    if (osc_stop || !time_valid) {
+    if (!time_valid) {
         rtc_valid_ = false;
         return false;
     }
     time_t epoch = makeUtcEpoch(utc_tm);
     if (epoch > Config::TIME_VALID_EPOCH) {
+        if (osc_stop) {
+            rtc_.clearOscillatorStop();
+            rtc_lost_power_ = false;
+        }
         rtc_valid_ = true;
         setSystemTime(epoch);
         return true;
     }
+    rtc_valid_ = false;
     return false;
 }
 


### PR DESCRIPTION
When RTC time is valid but OS (Oscillator Stop) bit is set, clear the bit instead of marking RTC as lost power. This prevents false "Lost" status when RTC battery is good and time is accurate.

## Summary
Describe your changes.

## Checklist
- [ ] I have read CONTRIBUTING.md and agree to the CLA.
- [ ] I tested my changes or explained why tests are not applicable.
- [ ] I updated documentation if needed.
