### PR TITLE
Option to show date in ISO format

### DIFF
--- a/src/config/AppConfig.h
+++ b/src/config/AppConfig.h
@@ -75,6 +75,20 @@ namespace Config {
         return static_cast<Language>(value);
     }
 
+    enum class DateFormat : uint8_t {
+        MDY = 0,  // MM/DD/YYYY
+        DMY = 1,  // DD.MM.YYYY
+        ISO = 2,  // YYYY-MM-DD
+        COUNT
+    };
+
+    inline DateFormat clampDateFormat(int value) {
+        if (value < 0 || value >= static_cast<int>(DateFormat::COUNT)) {
+            return DateFormat::DMY;
+        }
+        return static_cast<DateFormat>(value);
+    }
+
     enum class RtcMode : uint8_t {
         Auto = 0,
         Pcf8523 = 1,
@@ -612,7 +626,7 @@ namespace Config {
         float temp_offset = 0.0f;
         float hum_offset = 0.0f;
         bool units_c = true;
-        bool units_mdy = false;
+        DateFormat date_format = DateFormat::DMY;
         bool night_mode = false;
         bool header_status_enabled = true;
         bool led_indicators = true;

--- a/src/modules/StorageManager.cpp
+++ b/src/modules/StorageManager.cpp
@@ -690,7 +690,12 @@ bool StorageManager::loadConfig() {
         readValue(ui, "temp_offset", loaded.temp_offset);
         readValue(ui, "hum_offset", loaded.hum_offset);
         readValue(ui, "units_c", loaded.units_c);
-        readValue(ui, "units_mdy", loaded.units_mdy);
+        bool legacy_units_mdy = false;
+        readValue(ui, "units_mdy", legacy_units_mdy);
+        int date_format_raw = static_cast<int>(
+            legacy_units_mdy ? Config::DateFormat::MDY : Config::DateFormat::DMY);
+        readValue(ui, "date_format", date_format_raw);
+        loaded.date_format = Config::clampDateFormat(date_format_raw);
         readValue(ui, "night_mode", loaded.night_mode);
         readValue(ui, "header_status_enabled", loaded.header_status_enabled);
         readValue(ui, "led_indicators", loaded.led_indicators);
@@ -812,7 +817,7 @@ bool StorageManager::saveConfigInternal() {
     ui["temp_offset"] = config_.temp_offset;
     ui["hum_offset"] = config_.hum_offset;
     ui["units_c"] = config_.units_c;
-    ui["units_mdy"] = config_.units_mdy;
+    ui["date_format"] = static_cast<uint8_t>(config_.date_format);
     ui["night_mode"] = config_.night_mode;
     ui["header_status_enabled"] = config_.header_status_enabled;
     ui["led_indicators"] = config_.led_indicators;

--- a/src/ui/UiController.cpp
+++ b/src/ui/UiController.cpp
@@ -979,25 +979,20 @@ bool UiController::webSetNtpServer(const String &server) {
 
 bool UiController::webSetUnitsC(bool units_c) {
     if (units_c == temp_units_c) {
-        const bool expected_mdy = !units_c;
-        if (date_units_mdy != expected_mdy) {
-            date_units_mdy = expected_mdy;
-            storage.config().units_mdy = expected_mdy;
-            clock_ui_dirty = true;
-        }
         return true;
     }
     const bool previous_units_c = temp_units_c;
-    const bool previous_units_mdy = date_units_mdy;
+    const Config::DateFormat previous_date_format = date_format_;
     temp_units_c = units_c;
-    date_units_mdy = !units_c;
+    // °F implies MM/DD/YYYY, °C implies DD.MM.YYYY.
+    date_format_ = units_c ? Config::DateFormat::DMY : Config::DateFormat::MDY;
     storage.config().units_c = temp_units_c;
-    storage.config().units_mdy = date_units_mdy;
+    storage.config().date_format = date_format_;
     if (!storage.saveConfig(true)) {
         temp_units_c = previous_units_c;
-        date_units_mdy = previous_units_mdy;
+        date_format_ = previous_date_format;
         storage.config().units_c = previous_units_c;
-        storage.config().units_mdy = previous_units_mdy;
+        storage.config().date_format = previous_date_format;
         clock_ui_dirty = true;
         data_dirty = true;
         LOGE("UI", "failed to persist temperature unit change");
@@ -2159,19 +2154,42 @@ void UiController::update_clock_labels() {
         safe_label_set_text(objects.label_time_ampm_title_2, show_ampm ? ampm_buf : "");
         set_label_hidden(objects.label_time_ampm_title_2, !show_ampm);
     }
-    if (date_units_mdy) {
-        snprintf(buf, sizeof(buf), "%02d/%02d/%04d",
-                 local_tm.tm_mon + 1,
-                 local_tm.tm_mday,
-                 local_tm.tm_year + 1900);
-    } else {
-        snprintf(buf, sizeof(buf), "%02d.%02d.%04d",
-                 local_tm.tm_mday,
-                 local_tm.tm_mon + 1,
-                 local_tm.tm_year + 1900);
+    switch (date_format_) {
+        case Config::DateFormat::MDY:
+            snprintf(buf, sizeof(buf), "%02d/%02d/%04d",
+                     local_tm.tm_mon + 1,
+                     local_tm.tm_mday,
+                     local_tm.tm_year + 1900);
+            break;
+        case Config::DateFormat::ISO:
+            snprintf(buf, sizeof(buf), "%04d-%02d-%02d",
+                     local_tm.tm_year + 1900,
+                     local_tm.tm_mon + 1,
+                     local_tm.tm_mday);
+            break;
+        case Config::DateFormat::DMY:
+        default:
+            snprintf(buf, sizeof(buf), "%02d.%02d.%04d",
+                     local_tm.tm_mday,
+                     local_tm.tm_mon + 1,
+                     local_tm.tm_year + 1900);
+            break;
     }
     if (objects.label_date_value_1) safe_label_set_text(objects.label_date_value_1, buf);
     if (objects.label_date_value_2) safe_label_set_text(objects.label_date_value_2, buf);
+    update_date_format_button();
+}
+
+void UiController::update_date_format_button() {
+    if (!objects.label_btn_date_format) return;
+    const char *text = "DMY";
+    switch (date_format_) {
+        case Config::DateFormat::MDY: text = "MDY"; break;
+        case Config::DateFormat::ISO: text = "ISO"; break;
+        case Config::DateFormat::DMY:
+        default: text = "DMY"; break;
+    }
+    safe_label_set_text(objects.label_btn_date_format, text);
 }
 
 void UiController::set_button_enabled(lv_obj_t *btn, bool enabled) {
@@ -2968,21 +2986,12 @@ void UiController::init_ui_defaults() {
         lv_obj_set_style_text_color(objects.label_btn_night_mode, color_inactive(), LV_PART_MAIN | LV_STATE_DISABLED);
     }
     ui_language = storage.config().language;
-    date_units_mdy = storage.config().units_mdy;
+    date_format_ = storage.config().date_format;
     time_format_24h_ = storage.config().time_format_24h;
     rtc_detection_saved_mode_ = storage.config().rtc_mode;
     rtc_detection_pending_mode_ = rtc_detection_saved_mode_;
     reset_pressure_altitude_pending();
     pressure_altitude_overlay_open_ = false;
-    const bool expected_units_mdy = !temp_units_c;
-    if (date_units_mdy != expected_units_mdy) {
-        date_units_mdy = expected_units_mdy;
-        storage.config().units_mdy = expected_units_mdy;
-        if (!storage.saveConfig(true)) {
-            storage.requestSave();
-            LOGW("UI", "failed to normalize date format for unit system");
-        }
-    }
     language_dirty = false;
     header_status_enabled = storage.config().header_status_enabled;
     UiLocalization::applyCurrentLanguage(*this);

--- a/src/ui/UiController.h
+++ b/src/ui/UiController.h
@@ -422,6 +422,7 @@ private:
     void update_status_message(uint32_t now_ms, bool gas_warmup);
     void update_diag_log_ui();
     void update_clock_labels();
+    void update_date_format_button();
     bool pressure_altitude_is_set() const;
     int pressure_altitude_meters() const;
     float pressure_absolute_to_msl_hpa(float pressure_hpa, int altitude_m) const;
@@ -593,7 +594,7 @@ private:
     void on_night_mode_event(lv_event_t *e);
     void on_units_c_f_event(lv_event_t *e);
     void on_time_format_toggle_event(lv_event_t *e);
-    void on_units_mdy_event(lv_event_t *e);
+    void on_date_format_event(lv_event_t *e);
     void on_led_indicators_event(lv_event_t *e);
     void on_alert_blink_event(lv_event_t *e);
     void on_co2_calib_event(lv_event_t *e);
@@ -770,7 +771,7 @@ private:
     static void on_night_mode_event_cb(lv_event_t *e);
     static void on_units_c_f_event_cb(lv_event_t *e);
     static void on_time_format_toggle_event_cb(lv_event_t *e);
-    static void on_units_mdy_event_cb(lv_event_t *e);
+    static void on_date_format_event_cb(lv_event_t *e);
     static void on_led_indicators_event_cb(lv_event_t *e);
     static void on_alert_blink_event_cb(lv_event_t *e);
     static void on_co2_calib_event_cb(lv_event_t *e);
@@ -1001,7 +1002,7 @@ private:
     int pressure_altitude_pending_m_ = Config::PRESSURE_ALTITUDE_DEFAULT_M;
     bool pressure_altitude_overlay_open_ = false;
     Config::Language ui_language = Config::Language::EN;
-    bool date_units_mdy = false;
+    Config::DateFormat date_format_ = Config::DateFormat::DMY;
     bool time_format_24h_ = true;
     bool language_dirty = false;
     bool blink_state = true;

--- a/src/ui/UiControllerEvents.cpp
+++ b/src/ui/UiControllerEvents.cpp
@@ -112,7 +112,7 @@ void UiController::on_confirm_cancel_event_cb(lv_event_t *e) { if (instance_) in
 void UiController::on_night_mode_event_cb(lv_event_t *e) { if (instance_) instance_->on_night_mode_event(e); }
 void UiController::on_units_c_f_event_cb(lv_event_t *e) { if (instance_) instance_->on_units_c_f_event(e); }
 void UiController::on_time_format_toggle_event_cb(lv_event_t *e) { if (instance_) instance_->on_time_format_toggle_event(e); }
-void UiController::on_units_mdy_event_cb(lv_event_t *e) { if (instance_) instance_->on_units_mdy_event(e); }
+void UiController::on_date_format_event_cb(lv_event_t *e) { if (instance_) instance_->on_date_format_event(e); }
 void UiController::on_led_indicators_event_cb(lv_event_t *e) { if (instance_) instance_->on_led_indicators_event(e); }
 void UiController::on_alert_blink_event_cb(lv_event_t *e) { if (instance_) instance_->on_alert_blink_event(e); }
 void UiController::on_co2_calib_event_cb(lv_event_t *e) { if (instance_) instance_->on_co2_calib_event(e); }
@@ -780,14 +780,14 @@ void UiController::on_units_c_f_event(lv_event_t *e) {
     }
     lv_obj_t *btn = lv_event_get_target(e);
     bool use_c = lv_obj_has_state(btn, LV_STATE_CHECKED);
-    const bool use_mdy = !use_c;
-    if (use_c == temp_units_c && use_mdy == date_units_mdy) {
+    if (use_c == temp_units_c) {
         return;
     }
     temp_units_c = use_c;
-    date_units_mdy = use_mdy;
+    // Sensible default: °F implies MM/DD/YYYY, °C implies DD.MM.YYYY.
+    date_format_ = use_c ? Config::DateFormat::DMY : Config::DateFormat::MDY;
     storage.config().units_c = temp_units_c;
-    storage.config().units_mdy = date_units_mdy;
+    storage.config().date_format = date_format_;
     persist_ui_config(storage, "unit system");
     clock_ui_dirty = true;
     sync_display_threshold_labels();
@@ -813,25 +813,18 @@ void UiController::on_time_format_toggle_event(lv_event_t *e) {
     publishWebUiSnapshot();
 }
 
-void UiController::on_units_mdy_event(lv_event_t *e) {
-    if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) {
+void UiController::on_date_format_event(lv_event_t *e) {
+    if (lv_event_get_code(e) != LV_EVENT_CLICKED) {
         return;
     }
-    lv_obj_t *btn = lv_event_get_target(e);
-    bool use_mdy = lv_obj_has_state(btn, LV_STATE_CHECKED);
-    const bool use_c = !use_mdy;
-    if (use_c == temp_units_c && use_mdy == date_units_mdy) {
-        return;
-    }
-    date_units_mdy = use_mdy;
-    temp_units_c = use_c;
-    storage.config().units_mdy = date_units_mdy;
-    storage.config().units_c = temp_units_c;
-    persist_ui_config(storage, "unit system");
+    // Cycle MDY -> DMY -> ISO -> MDY.
+    const uint8_t next = (static_cast<uint8_t>(date_format_) + 1) %
+                         static_cast<uint8_t>(Config::DateFormat::COUNT);
+    date_format_ = static_cast<Config::DateFormat>(next);
+    storage.config().date_format = date_format_;
+    persist_ui_config(storage, "date format");
     clock_ui_dirty = true;
-    sync_display_threshold_labels();
     update_clock_labels();
-    update_ui();
 }
 
 void UiController::on_restart_event(lv_event_t *e) {

--- a/src/ui/UiEventBinder.cpp
+++ b/src/ui/UiEventBinder.cpp
@@ -281,6 +281,7 @@ void UiEventBinder::bindAvailableEvents(UiController &owner, int screen_id) {
         {objects.btn_night_mode, UiController::on_night_mode_event_cb, LV_EVENT_VALUE_CHANGED},
         {objects.btn_units, UiController::on_units_c_f_event_cb, LV_EVENT_VALUE_CHANGED},
         {objects.btn_1224_toggle, UiController::on_time_format_toggle_event_cb, LV_EVENT_VALUE_CHANGED},
+        {objects.btn_date_format, UiController::on_date_format_event_cb, LV_EVENT_CLICKED},
         {objects.btn_led_indicators, UiController::on_led_indicators_event_cb, LV_EVENT_VALUE_CHANGED},
         {objects.btn_alert_blink, UiController::on_alert_blink_event_cb, LV_EVENT_VALUE_CHANGED},
         {objects.btn_co2_calib_asc, UiController::on_co2_calib_asc_event_cb, LV_EVENT_VALUE_CHANGED},

--- a/src/ui/screens.c
+++ b/src/ui/screens.c
@@ -5970,7 +5970,7 @@ void create_screen_page_clock() {
             lv_obj_t *obj = lv_obj_create(parent_obj);
             objects.btn_datetime_apply = obj;
             lv_obj_set_pos(obj, 20, 411);
-            lv_obj_set_size(obj, 225, 45);
+            lv_obj_set_size(obj, 140, 45);
             lv_obj_set_style_pad_left(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_pad_top(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_pad_right(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -5989,13 +5989,44 @@ void create_screen_page_clock() {
                     // label_btn_datetime_apply
                     lv_obj_t *obj = lv_label_create(parent_obj);
                     objects.label_btn_datetime_apply = obj;
-                    lv_obj_set_pos(obj, 11, 11);
-                    lv_obj_set_size(obj, 200, LV_SIZE_CONTENT);
+                    lv_obj_set_pos(obj, 6, 11);
+                    lv_obj_set_size(obj, 128, LV_SIZE_CONTENT);
                     lv_obj_clear_flag(obj, LV_OBJ_FLAG_CLICK_FOCUSABLE|LV_OBJ_FLAG_GESTURE_BUBBLE|LV_OBJ_FLAG_PRESS_LOCK|LV_OBJ_FLAG_SCROLLABLE|LV_OBJ_FLAG_SCROLL_CHAIN_HOR|LV_OBJ_FLAG_SCROLL_CHAIN_VER|LV_OBJ_FLAG_SCROLL_ELASTIC|LV_OBJ_FLAG_SCROLL_MOMENTUM|LV_OBJ_FLAG_SCROLL_WITH_ARROW|LV_OBJ_FLAG_SNAPPABLE);
                     add_style_style_text_primary(obj);
                     lv_obj_set_style_text_font(obj, &ui_font_jet_reg_18, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_obj_set_style_text_align(obj, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
                     lv_label_set_text(obj, "APPLY NOW");
+                }
+            }
+        }
+        {
+            // btn_date_format
+            lv_obj_t *obj = lv_obj_create(parent_obj);
+            objects.btn_date_format = obj;
+            lv_obj_set_pos(obj, 170, 411);
+            lv_obj_set_size(obj, 80, 45);
+            lv_obj_set_style_pad_left(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_pad_top(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_pad_right(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_pad_bottom(obj, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_clear_flag(obj, LV_OBJ_FLAG_CLICK_FOCUSABLE|LV_OBJ_FLAG_GESTURE_BUBBLE|LV_OBJ_FLAG_PRESS_LOCK|LV_OBJ_FLAG_SCROLLABLE|LV_OBJ_FLAG_SCROLL_CHAIN_HOR|LV_OBJ_FLAG_SCROLL_CHAIN_VER|LV_OBJ_FLAG_SCROLL_ELASTIC|LV_OBJ_FLAG_SCROLL_MOMENTUM|LV_OBJ_FLAG_SCROLL_WITH_ARROW|LV_OBJ_FLAG_SNAPPABLE);
+            add_style_style_card_base(obj);
+            lv_obj_set_style_border_width(obj, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_radius(obj, 15, LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_bg_opa(obj, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+            {
+                lv_obj_t *parent_obj = obj;
+                {
+                    // label_btn_date_format
+                    lv_obj_t *obj = lv_label_create(parent_obj);
+                    objects.label_btn_date_format = obj;
+                    lv_obj_set_pos(obj, 0, 11);
+                    lv_obj_set_size(obj, 80, LV_SIZE_CONTENT);
+                    lv_obj_clear_flag(obj, LV_OBJ_FLAG_CLICK_FOCUSABLE|LV_OBJ_FLAG_GESTURE_BUBBLE|LV_OBJ_FLAG_PRESS_LOCK|LV_OBJ_FLAG_SCROLLABLE|LV_OBJ_FLAG_SCROLL_CHAIN_HOR|LV_OBJ_FLAG_SCROLL_CHAIN_VER|LV_OBJ_FLAG_SCROLL_ELASTIC|LV_OBJ_FLAG_SCROLL_MOMENTUM|LV_OBJ_FLAG_SCROLL_WITH_ARROW|LV_OBJ_FLAG_SNAPPABLE);
+                    add_style_style_text_primary(obj);
+                    lv_obj_set_style_text_font(obj, &ui_font_jet_reg_18, LV_PART_MAIN | LV_STATE_DEFAULT);
+                    lv_obj_set_style_text_align(obj, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
+                    lv_label_set_text(obj, "DMY");
                 }
             }
         }

--- a/src/ui/screens.h
+++ b/src/ui/screens.h
@@ -410,6 +410,8 @@ typedef struct _objects_t {
     lv_obj_t *label_btn_set_date_year_plus;
     lv_obj_t *btn_1224_toggle;
     lv_obj_t *label_btn_1224_toggle;
+    lv_obj_t *btn_date_format;
+    lv_obj_t *label_btn_date_format;
     lv_obj_t *card_time_1;
     lv_obj_t *label_time_value_1;
     lv_obj_t *label_date_value_1;


### PR DESCRIPTION
## Summary

Following up on the Japanese language addition, I added the ability to show the dates in ISO format (YYYY-MM-DD). The option is added in the date/time settings page, next to the 12/24 button. Since the "apply now" button is now shorter, German "JETZT ANWENDEN" becomes two lines (other languages looked fine). Google Translate tells me it means "apply now" and I think this can simply be "anwenden," but I don’t speak German so I left it intact.

There is a migration logic for the `units_mdy` boolean option, and keeps the sensible defaults for Fahrenheit → MM/DD/YYYY (for US) and Celsius → DD.MM.YYYY (EU).

It seems the `.eez-project` file was missing from the repo, so if you could either add that file to the repo, or update it on your end so that future changes will not revert this change, that would be great.

As in the other PR, if you prefer to have the commits squashed into one please let me know.

## Checklist

- [x] I have read CONTRIBUTING.md and agree to the CLA.
- [x] I tested my changes or explained why tests are not applicable.
- [x] I updated documentation if needed.
