### PR TITLE
Require recorded CLA signatures for contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,6 @@
 Describe your changes.
 
 ## Checklist
-- [ ] I have read CONTRIBUTING.md and agree to the CLA.
+- [ ] I understand that this PR cannot be merged until every contributor completes the CLA check.
 - [ ] I tested my changes or explained why tests are not applicable.
 - [ ] I updated documentation if needed.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,55 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, closed]
+
+# This workflow runs from the trusted base branch and never checks out PR code.
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  agreement:
+    name: CLA agreement
+    if: ${{ github.repository == '21cncstudio/project_aura' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify contributor signatures
+        if: |
+          (
+            github.event_name == 'pull_request_target' &&
+            (
+              github.event.action == 'opened' ||
+              github.event.action == 'synchronize' ||
+              (github.event.action == 'closed' && github.event.pull_request.merged == true)
+            )
+          ) ||
+          (
+            github.event_name == 'issue_comment' &&
+            (
+              github.event.comment.body == 'recheck' ||
+              github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+            )
+          )
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: https://github.com/21cncstudio/project_aura/blob/main/CLA.md
+          path-to-signatures: signatures/cla.json
+          branch: cla-signatures
+          allowlist: 21cncstudio,dependabot[bot],github-actions[bot],renovate[bot]
+          create-file-commit-message: Create Project Aura CLA signature registry
+          signed-commit-message: '$contributorName signed the Project Aura CLA in #$pullRequestNo'
+          custom-notsigned-prcomment: |
+            Thank you for contributing to Project Aura. Before this pull request can be merged,
+            every contributor must read the [Project Aura CLA]($pathToCLADocument) and add this
+            exact comment to the pull request:
+
+            `I have read the CLA Document and I hereby sign the CLA`
+          custom-allsigned-prcomment: All contributors have signed the Project Aura CLA.

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,8 @@
 # Contributor License Agreement (Individual)
 
-By submitting a contribution to this repository, you agree:
+Version 1.0 — 17 July 2026
+
+By signing this agreement for a pull request, you agree:
 
 1. You grant Volodymyr Papush (21CNCStudio) a perpetual, worldwide, non-exclusive, royalty-free,
    irrevocable, transferable license to use, reproduce, modify, prepare derivative works,
@@ -11,4 +13,13 @@ By submitting a contribution to this repository, you agree:
 3. You understand that your contribution may be included in open-source and commercial
    distributions.
 
-If you do not agree to these terms, do not submit a contribution.
+You sign this agreement by posting the following exact comment in a Project Aura pull request:
+
+`I have read the CLA Document and I hereby sign the CLA`
+
+The repository records your GitHub username, the CLA version, and the pull request in which you
+signed. Your signature covers that pull request and later contributions submitted under the same
+CLA version. If the CLA changes, you may be asked to sign the new version.
+
+If you do not agree to these terms, do not sign the agreement or submit a contribution for
+inclusion in Project Aura.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,13 @@ open-source community such an amazing place to learn, inspire, and create.
 Project Aura uses a **Dual Licensing** model (GPLv3 for open source, Commercial for proprietary use).
 To maintain this model, I require all contributors to agree to a Contributor License Agreement (CLA).
 
-**By submitting a pull request, you automatically agree to the terms in [CLA.md](CLA.md).**
+Agreement is explicit, not automatic. When you open your first pull request, the CLA check will ask
+you to read [CLA.md](CLA.md) and post this exact comment in the pull request:
+
+`I have read the CLA Document and I hereby sign the CLA`
+
+The pull request cannot be merged until every contributor has signed the current CLA version. The
+signature is normally required only once; a changed CLA version may require a new signature.
 
 This agreement gives 21CNCStudio the right to use your contribution in both the open-source and
 commercial versions of the firmware, while you retain copyright ownership of your code.
@@ -35,6 +41,7 @@ I love pull requests! Here's a quick guide:
 4.  **Pull Request**:
     *   Open a PR against the `main` branch.
     *   Describe your changes clearly.
+    *   Complete the CLA signature requested by the automated check.
 
 ## Questions?
 


### PR DESCRIPTION
## Summary

- require an explicit CLA signature comment from every external contributor
- store versioned signatures on a dedicated `cla-signatures` branch
- add a blocking `CLA agreement` check for pull requests
- document the signing flow and replace the non-enforced template checkbox

## Security

The workflow uses `pull_request_target`, does not check out or execute pull-request code, and pins the CLA action to commit `ca4a40a7d1004f18d9960b404b97e5f30a505a08`.

## Rollout

After merge, create the unprotected `cla-signatures` branch and require the `CLA agreement` status check for `main`.