### PR TITLE
Run CLA check when pull requests reopen

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, synchronize, closed]
+    types: [opened, reopened, synchronize, closed]
 
 # This workflow runs from the trusted base branch and never checks out PR code.
 permissions:
@@ -25,6 +25,7 @@ jobs:
             github.event_name == 'pull_request_target' &&
             (
               github.event.action == 'opened' ||
+              github.event.action == 'reopened' ||
               github.event.action == 'synchronize' ||
               (github.event.action == 'closed' && github.event.pull_request.merged == true)
             )

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -44,7 +44,8 @@ jobs:
           path-to-document: https://github.com/21cncstudio/project_aura/blob/main/CLA.md
           path-to-signatures: signatures/cla.json
           branch: cla-signatures
-          allowlist: 21cncstudio,dependabot[bot],github-actions[bot],renovate[bot]
+          # The action compares GitHub logins case-sensitively; keep both owner spellings.
+          allowlist: 21cncstudio,21CNCStudio,dependabot[bot],github-actions[bot],renovate[bot]
           create-file-commit-message: Create Project Aura CLA signature registry
           signed-commit-message: '$contributorName signed the Project Aura CLA in #$pullRequestNo'
           custom-notsigned-prcomment: |


### PR DESCRIPTION
Adds the `reopened` event to the mandatory CLA workflow so reopened contributions are revalidated. This PR also exercises the new `CLA agreement` status check after #133.