### PR TITLE
Strengthen individual contributor license agreement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,6 @@ Describe your changes.
 
 ## Checklist
 - [ ] I understand that this PR cannot be merged until every contributor completes the CLA check.
+- [ ] I disclosed any third-party material and employer or organisation rights affecting this PR.
 - [ ] I tested my changes or explained why tests are not applicable.
 - [ ] I updated documentation if needed.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -34,7 +34,7 @@ jobs:
             github.event_name == 'issue_comment' &&
             (
               github.event.comment.body == 'recheck' ||
-              github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+              github.event.comment.body == 'I have read and agree to the Project Aura Individual Contributor License Agreement v2.0, and I hereby sign it.'
             )
           )
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
@@ -43,7 +43,7 @@ jobs:
         with:
           path-to-document: https://github.com/21cncstudio/project_aura/blob/main/CLA.md
           # Change this path when CLA.md moves to a new version so contributors re-sign.
-          path-to-signatures: signatures/v1.0/cla.json
+          path-to-signatures: signatures/v2.0/cla.json
           branch: cla-signatures
           # The action compares GitHub logins case-sensitively; keep both owner spellings.
           allowlist: 21cncstudio,21CNCStudio,dependabot[bot],github-actions[bot],renovate[bot]
@@ -53,7 +53,6 @@ jobs:
             Thank you for contributing to Project Aura. Before this pull request can be merged,
             every contributor must read the
             [Project Aura CLA](https://github.com/21cncstudio/project_aura/blob/main/CLA.md)
-            and add this exact comment to the pull request:
-
-            `I have read the CLA Document and I hereby sign the CLA`
+            and post the exact signature statement shown below.
+          custom-pr-sign-comment: I have read and agree to the Project Aura Individual Contributor License Agreement v2.0, and I hereby sign it.
           custom-allsigned-prcomment: All contributors have signed the Project Aura CLA.

--- a/CLA.md
+++ b/CLA.md
@@ -1,25 +1,169 @@
-# Contributor License Agreement (Individual)
+# Project Aura Individual Contributor License Agreement
 
-Version 1.0 — 17 July 2026
+Version 2.0 - 17 July 2026
 
-By signing this agreement for a pull request, you agree:
+This Individual Contributor License Agreement (the "Agreement") is between you ("You") and
+Volodymyr Papush, acting in his personal capacity (the "Licensor"). It explains the rights You grant
+when You contribute to Project Aura. This is a legally binding agreement, so please read it
+carefully before signing.
 
-1. You grant Volodymyr Papush (21CNCStudio) a perpetual, worldwide, non-exclusive, royalty-free,
-   irrevocable, transferable license to use, reproduce, modify, prepare derivative works,
-   distribute, publicly perform, publicly display, and sublicense your contribution under any
-   license terms, including proprietary licenses.
-2. You represent that you have the right to grant this license and that your contribution is your
-   original work or you have sufficient rights to submit it.
-3. You understand that your contribution may be included in open-source and commercial
-   distributions.
+## 1. Definitions
 
-You sign this agreement by posting the following exact comment in a Project Aura pull request:
+"Contribution" means any original work of authorship or other material that You intentionally
+submit for inclusion in Project Aura, including source code, object code, firmware, documentation,
+tests, designs, schematics, data, configuration, and modifications to existing material. A
+Contribution may be submitted by pull request, commit, patch, or another method accepted by the
+Licensor. Material clearly marked "Not a Contribution" is excluded.
 
-`I have read the CLA Document and I hereby sign the CLA`
+"Project Aura" means the Project Aura repositories, firmware, hardware and enclosure materials,
+documentation, distributions, and derivative or successor projects maintained or licensed by the
+Licensor, including rebranded, customised, private, internal, and customer-specific versions.
 
-The repository records your GitHub username, the CLA version, and the pull request in which you
-signed. Your signature covers that pull request and later contributions submitted under the same
-CLA version. If the CLA changes, you may be asked to sign the new version.
+"Control" means the power to grant a license without violating an agreement with, or owing payment
+to, a third party.
 
-If you do not agree to these terms, do not sign the agreement or submit a contribution for
-inclusion in Project Aura.
+## 2. Copyright and related-rights license
+
+For every Contribution, You grant the Licensor a perpetual, worldwide, non-exclusive, royalty-free,
+fully paid-up, irrevocable (to the maximum extent permitted by law), transferable, and fully
+sublicensable license under all copyright, database, design, semiconductor-topography, and similar
+or neighbouring rights that You own or Control to:
+
+- use, reproduce, modify, adapt, translate, and prepare derivative works of the Contribution;
+- compile, manufacture, have manufactured, host, run, publicly perform, publicly display, make
+  available, communicate, distribute, import, market, offer for sale, sell, and otherwise exploit
+  the Contribution;
+- combine the Contribution with any software, firmware, hardware, designs, data, content, products,
+  or services; and
+- license or sublicense the Contribution, in source, object, or any other form, by itself or as part
+  of a larger work, under any terms chosen by the Licensor, including open-source,
+  source-available, commercial, proprietary, or closed-source terms, with or without charge.
+
+The Licensor may exercise these rights directly or through contractors, manufacturers,
+distributors, customers, service providers, licensees, and sublicensees. This Agreement itself does
+not require the Licensor to publish source code for a Contribution licensed under this Section or
+to obtain further consent from, or make any payment or accounting to, You. Separate licenses
+applying to third-party material remain unaffected.
+
+## 3. Patent license
+
+You grant the Licensor and its transferees and sublicensees a perpetual, worldwide, non-exclusive,
+royalty-free, fully paid-up, irrevocable (to the maximum extent permitted by law), transferable,
+and sublicensable patent license to make, have made, use, offer for sale, sell, import, and otherwise
+exploit the Contribution and works incorporating the Contribution.
+
+This patent license applies only to patent claims that You now or later own or Control and that are
+necessarily infringed by the Contribution alone or by its combination with Project Aura as
+submitted. Except for this limited grant, no other patent rights are licensed.
+
+You agree not to assert, or authorise another party to assert, any patent claim within this license
+against the Licensor or its transferees, licensees, sublicensees, distributors, customers, or
+successors for exercising the rights granted by this Agreement. Any such assertion is a material
+breach of this Agreement.
+
+## 4. Your ownership and continued use
+
+You retain ownership of Your Contribution. You may use, license, sell, or contribute it elsewhere.
+The rights granted to the Licensor are non-exclusive, but the grants already made under this
+Agreement cannot be withdrawn for Contributions already submitted under this Agreement.
+
+This Agreement is an additional license to the Licensor. It does not reduce rights that anyone may
+receive under an open-source or other public license applied to a Project Aura distribution.
+
+## 5. Your representations
+
+You represent that:
+
+1. You have the legal capacity and authority to enter into this Agreement.
+2. Each Contribution is Your original work, or You otherwise have sufficient rights to submit it
+   and grant every license in this Agreement.
+3. Your grant does not violate any agreement or duty to another person or entity.
+4. If an employer, client, university, or other entity may own or Control rights in a Contribution,
+   You have obtained all permissions or waivers needed to make the Contribution and grant these
+   rights. If that entity owns the Contribution and You are not authorised to bind it, this
+   Individual Agreement is not sufficient; an authorised representative of the entity must grant
+   the required rights in a separate written agreement before the Contribution is accepted.
+5. You will identify in the pull request any third-party material included in a Contribution and
+   provide its source, copyright notice, and applicable license. The licenses in this Agreement
+   apply to third-party material only to the extent You have authority to grant them.
+6. The Contribution does not knowingly contain another party's confidential information, trade
+   secrets, or material submitted in breach of a duty of confidentiality.
+
+The Licensor may request reasonable evidence of Your authority or permissions before accepting a
+Contribution.
+
+## 6. Moral rights and attribution
+
+To the maximum extent permitted by law, You waive and agree not to assert any moral rights,
+author's rights, rights of integrity, rights of attribution, or similar rights in a Contribution
+against the Licensor or its transferees, licensees, sublicensees, distributors, customers, and
+successors. Where a waiver is not legally effective, You irrevocably consent to the exercise of the
+licensed rights, including modification, translation, combination with other material, and use with
+or without attribution.
+
+The Licensor may provide attribution but is not required to do so except where applicable law or a
+separately identified third-party license requires it.
+
+## 7. No confidentiality, support, or compensation
+
+A Contribution is provided without an obligation of confidentiality. The Licensor is not required
+to use, merge, distribute, or continue maintaining any Contribution.
+
+Unless separately agreed in writing, no payment, royalty, employment, partnership, support,
+maintenance, or other obligation arises from a Contribution. Except for the representations in
+Section 5, You provide each Contribution "as is", without warranties or conditions of any kind.
+
+## 8. Duration and future Contributions
+
+Your signature covers the pull request in which You sign and later Contributions submitted by You
+under this same Agreement version. You may end coverage for future Contributions by giving the
+Licensor clear written notice, but that notice does not revoke or limit rights already granted.
+
+If this Agreement is changed, the Licensor may require You to sign a new version before accepting
+further Contributions. A new version does not change rights already granted under an earlier signed
+version unless both parties expressly agree in writing.
+
+## 9. Transfer and assignment
+
+The Licensor may transfer or assign this Agreement and any rights granted under it, in whole or in
+part, to a person or entity that acquires, operates, maintains, distributes, licenses, or
+commercialises Project Aura or related products or services. The rights granted to existing
+licensees and sublicensees survive such a transfer.
+
+For clarity, the Licensor may license or sublicense the Contributions to, or assign this Agreement
+and its rights to, an existing or future company owned or controlled by the Licensor without
+obtaining further consent from You.
+
+You may not assign this Agreement without the Licensor's prior written consent, except that Your
+ownership of the Contribution may be transferred subject to the licenses already granted here.
+
+## 10. Governing law and courts
+
+This Agreement and any non-contractual obligations arising from it are governed by the laws of
+England and Wales, without regard to conflict-of-laws rules. The courts of England and Wales have
+exclusive jurisdiction over disputes arising from or connected with this Agreement.
+
+## 11. General terms
+
+This Agreement is the entire agreement between You and the Licensor concerning the rights granted
+in Contributions, and it replaces earlier discussions or statements on that subject for
+Contributions covered by this version. A failure to enforce a provision is not a waiver. If a
+provision is held invalid or unenforceable, it will be limited or adjusted only as much as necessary,
+and the remaining provisions continue in effect.
+
+The English-language version of this Agreement controls. Headings are for convenience and do not
+limit the terms.
+
+## 12. Electronic signature and record
+
+You sign this Agreement by posting the following exact comment in a Project Aura pull request:
+
+`I have read and agree to the Project Aura Individual Contributor License Agreement v2.0, and I hereby sign it.`
+
+By posting that comment, You confirm that the GitHub account is under Your control, that You intend
+the comment to be Your electronic signature, and that You agree to electronic records. The
+signature record may include Your GitHub username and account ID, the Agreement version, repository,
+pull request, comment ID, and timestamp, and may be stored in a publicly accessible repository.
+
+If You do not agree to every term above, do not post the signature comment or submit a Contribution
+for inclusion in Project Aura.

--- a/CLA.md
+++ b/CLA.md
@@ -125,14 +125,12 @@ version unless both parties expressly agree in writing.
 
 ## 9. Transfer and assignment
 
-The Licensor may transfer or assign this Agreement and any rights granted under it, in whole or in
-part, to a person or entity that acquires, operates, maintains, distributes, licenses, or
-commercialises Project Aura or related products or services. The rights granted to existing
-licensees and sublicensees survive such a transfer.
-
-For clarity, the Licensor may license or sublicense the Contributions to, or assign this Agreement
-and its rights to, an existing or future company owned or controlled by the Licensor without
-obtaining further consent from You.
+Without obtaining further consent from You, the Licensor may license or sublicense Contributions
+to, and may transfer or assign this Agreement and any rights granted under it, in whole or in part,
+to any person or entity, whether or not affiliated with, owned by, or controlled by the Licensor.
+This includes an existing or future company, purchaser, investor, business partner, customer, or
+other successor or licensee. The rights granted to existing licensees and sublicensees survive any
+such transfer or assignment.
 
 You may not assign this Agreement without the Licensor's prior written consent, except that Your
 ownership of the Contribution may be transferred subject to the licenses already granted here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,20 @@ To maintain this model, I require all contributors to agree to a Contributor Lic
 Agreement is explicit, not automatic. When you open your first pull request, the CLA check will ask
 you to read [CLA.md](CLA.md) and post this exact comment in the pull request:
 
-`I have read the CLA Document and I hereby sign the CLA`
+`I have read and agree to the Project Aura Individual Contributor License Agreement v2.0, and I hereby sign it.`
 
 The pull request cannot be merged until every contributor has signed the current CLA version. The
 signature is normally required only once; a changed CLA version may require a new signature.
 
-This agreement gives 21CNCStudio the right to use your contribution in both the open-source and
-commercial versions of the firmware, while you retain copyright ownership of your code.
+This agreement gives Volodymyr Papush personally the right to use your contribution in both the
+open-source and commercial versions of the firmware, while you retain copyright ownership of your
+code. The agreement allows those rights to be licensed or transferred to a company later.
+
+If an employer, client, university, or another organisation may own rights in your contribution,
+obtain its written permission before signing. If the organisation owns the contribution and you
+cannot bind it, contact the maintainer before submitting; an authorised representative must sign a
+separate written agreement before the contribution can be accepted.
+Disclose all third-party code or other material, together with its source and license, in the PR.
 
 ## Found a Bug?
 


### PR DESCRIPTION
## Summary

- replace the short CLA with Individual CLA v2 naming Volodymyr Papush personally as Licensor
- grant broad copyright, related-rights, patent, commercial, proprietary, sublicensing, and transfer rights
- allow transfer or licensing to affiliated or unrelated companies without renewed contributor consent
- add employer/organisation ownership and third-party material safeguards
- use the laws and courts of England and Wales
- require an exact v2 electronic signature and a versioned signature registry

## Validation

- parsed `.github/workflows/cla.yml` successfully
- verified the exact v2 signature phrase in the CLA, contributor guide, and workflow
- verified old v1 wording is absent
- verified no closed product names are present
- `git diff --check` passes (line-ending conversion warnings only)