### PR TITLE
Credit Naoki Mizuno's contributions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,20 @@
+# Project Aura Contributors
+
+Project Aura is strengthened by people who test the device, report problems, propose improvements,
+and contribute code, translations, and documentation.
+
+This file also records contributions that were manually integrated or substantially reworked by
+the maintainer instead of merging the original pull request directly.
+
+## Community contributors
+
+### [Naoki Mizuno](https://github.com/naoki-mizuno)
+
+- Japanese UI localization, translation, and font integration from
+  [PR #123](https://github.com/21cncstudio/project_aura/pull/123), integrated into Project Aura in
+  [c15953b](https://github.com/21cncstudio/project_aura/commit/c15953b).
+- Configurable MDY, DMY, and ISO date formats from
+  [PR #124](https://github.com/21cncstudio/project_aura/pull/124), incorporated in reworked form in
+  [343a78b](https://github.com/21cncstudio/project_aura/commit/343a78b).
+
+Thank you for helping make Project Aura more useful and accessible.

--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ the experience of building a real device themselves.
 
 ## Contributing
 Contributions are welcome! Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) for details on the process for submitting pull requests and the Contributor License Agreement (CLA).
+Community contributions that were manually integrated or reworked are acknowledged in [`CONTRIBUTORS.md`](CONTRIBUTORS.md).
 
 Found a bug? Open an Issue: https://github.com/21cncstudio/project_aura/issues
 Have a question? Ask in Discussions: https://github.com/21cncstudio/project_aura/discussions


### PR DESCRIPTION
## Summary

- add a visible `CONTRIBUTORS.md` record for Naoki Mizuno
- link Japanese localization PR #123 to commit `c15953b`
- link configurable date format PR #124 to commit `343a78b`
- link the contributor record from the README
- include Naoki's requested `Co-authored-by` trailer using the email he provided

## Why

These contributions were manually integrated or substantially reworked instead of merging the original PR commits directly. This records the provenance and attribution without rewriting the published `main` history.

## Validation

- verified both PR and resulting commit links
- verified the exact `Co-authored-by: Naoki Mizuno <naoki.mizuno.256@gmail.com>` trailer
- `git diff --check` passes (line-ending conversion warnings only)
- confirmed the unrelated `docs/OEM_FIRMWARE_TRUST.md` file is not part of this branch diff