### PR TITLE
Add Aura Admin release package builder

### DIFF
--- a/docs/releases/RELEASING.md
+++ b/docs/releases/RELEASING.md
@@ -4,29 +4,44 @@
 - Edit `platformio.ini`:
   - `-DAPP_VERSION=\"X.Y.Z\"`
 
-## 2) Prepare assets
-Run:
+## 2) Create the Aura Admin package
+
+One-time setup on the release computer:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File scripts\prepare_release_assets.ps1 -Version X.Y.Z
+powershell -ExecutionPolicy Bypass -File scripts\create_installer_release_key.ps1
 ```
 
-This prepares files in `release-assets/vX.Y.Z` and refreshes local website installer files in `web-installer/`.
+Keep the generated DPAPI-protected private key on this Windows account. Add the
+public PEM and the printed key ID to `AURA_FIRMWARE_SIGNING_PUBLIC_KEYS` in Aura
+Link.
 
-Important:
-- GitHub Release should publish OTA file only.
-- Full installer binaries/manifests are for your private hosting workflow.
+For every Stable release, run:
 
-Main generated files:
-- `bootloader.bin`
-- `partitions.bin`
-- `boot_app0.bin`
-- `firmware.bin`
-- `littlefs.bin`
-- `manifest.json`
-- `manifest-update.json`
-- `project_aura_X.Y.Z_ota_firmware.bin`
-- `sha256sums.txt`
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\prepare_installer_release.ps1 -Version X.Y.Z
+```
+
+The command builds the firmware, checks that Git is clean, hashes every binary,
+signs the release metadata with the control-plane Ed25519 key, and creates:
+
+`release-assets/vX.Y.Z/aura-aq-vX.Y.Z-stable.aura-release.zip`
+
+Upload that ZIP to **Aura Admin -> Firmware & Installers**. Import creates a
+Draft. Publishing is a separate action.
+
+Recovery is deliberately packaged separately:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\prepare_installer_release.ps1 `
+  -Version X.Y.Z -Channel recovery -RecoveryBinary C:\prepared\recovery.bin
+```
+
+The Stable ZIP never contains Recovery firmware.
+
+The package signature protects release metadata and distribution artifacts. It
+is separate from the experimental device OTA signing work and from ESP32 Secure
+Boot.
 
 ## 3) Publish to GitHub Release
 Recommended command:
@@ -42,9 +57,9 @@ Notes:
   - `project_aura_X.Y.Z_ota_firmware.bin`
 
 ## 4) Website usage
-- Keep HTML installer block on your site.
-- Keep manifests on your own hosting (`/wp-content/uploads/aura-installer/...`).
-- Point manifest `path` fields to your storage/CDN links.
+- Aura Admin publishes immutable binaries to Private Blob.
+- The protected Installer receives short-lived URLs from the current release pointer.
+- Rollback changes the pointer; it never overwrites a published binary.
 
 ## 5) OTA dashboard update
 - Use `project_aura_X.Y.Z_ota_firmware.bin` in `/dashboard -> System -> Update Firmware`.

--- a/scripts/create_installer_release_key.ps1
+++ b/scripts/create_installer_release_key.ps1
@@ -1,0 +1,70 @@
+param(
+  [string]$KeyDirectory = (Join-Path $env:USERPROFILE ".project_aura\signing"),
+  [string]$NodePath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.Security
+
+$root = Resolve-Path (Join-Path $PSScriptRoot "..")
+$privatePath = Join-Path $KeyDirectory "installer-release-private-key.dpapi"
+$publicPath = Join-Path $KeyDirectory "installer-release-public-key.pem"
+$metadataPath = Join-Path $KeyDirectory "installer-release-key.json"
+$node = $NodePath
+if (-not $node) {
+  $node = (Get-Command node -ErrorAction SilentlyContinue).Source
+}
+if (-not $node) {
+  $node = Join-Path $env:ProgramFiles "nodejs\node.exe"
+}
+if (-not (Test-Path $node)) {
+  $node = Join-Path $env:USERPROFILE ".cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe"
+}
+if (-not (Test-Path $node)) {
+  throw "Node.js is required. Install Node.js or pass -NodePath <path-to-node.exe>."
+}
+
+if (Test-Path $privatePath) {
+  throw "A protected installer release key already exists at $privatePath"
+}
+
+New-Item -ItemType Directory -Force -Path $KeyDirectory | Out-Null
+$tempPrivate = Join-Path ([System.IO.Path]::GetTempPath()) ("aura-release-" + [guid]::NewGuid() + ".pem")
+$tempPublic = Join-Path ([System.IO.Path]::GetTempPath()) ("aura-release-" + [guid]::NewGuid() + ".pub.pem")
+
+try {
+  & $node (Join-Path $PSScriptRoot "generate_installer_release_key.mjs") --private-out $tempPrivate --public-out $tempPublic
+  if ($LASTEXITCODE -ne 0) {
+    throw "Node.js failed to generate the Ed25519 key pair."
+  }
+
+  $privateBytes = [System.IO.File]::ReadAllBytes($tempPrivate)
+  $protected = [System.Security.Cryptography.ProtectedData]::Protect(
+    $privateBytes,
+    $null,
+    [System.Security.Cryptography.DataProtectionScope]::CurrentUser
+  )
+  [System.IO.File]::WriteAllText($privatePath, [Convert]::ToBase64String($protected))
+
+  Copy-Item -LiteralPath $tempPublic -Destination $publicPath
+  $publicDer = & $node -e "const {createPublicKey,createHash}=require('node:crypto');const fs=require('node:fs');const k=createPublicKey(fs.readFileSync(process.argv[1]));process.stdout.write(createHash('sha256').update(k.export({type:'spki',format:'der'})).digest('hex').slice(0,16))" $publicPath
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($publicDer)) {
+    throw "Could not derive the public key ID."
+  }
+  $keyId = "aura-installer-ed25519-" + $publicDer.Trim()
+  [ordered]@{
+    key_id = $keyId
+    algorithm = "ed25519"
+    created_at = [DateTime]::UtcNow.ToString("o")
+    public_key_path = $publicPath
+  } | ConvertTo-Json | Set-Content -Encoding UTF8 -LiteralPath $metadataPath
+
+  Write-Host "Installer release signing key created."
+  Write-Host "Key ID: $keyId"
+  Write-Host "Protected private key: $privatePath"
+  Write-Host "Public key to add to AURA_FIRMWARE_SIGNING_PUBLIC_KEYS: $publicPath"
+} finally {
+  Remove-Item -LiteralPath $tempPrivate -Force -ErrorAction SilentlyContinue
+  Remove-Item -LiteralPath $tempPublic -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/generate_installer_release_key.mjs
+++ b/scripts/generate_installer_release_key.mjs
@@ -1,0 +1,24 @@
+import { generateKeyPairSync } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 2) {
+  args.set(process.argv[index], process.argv[index + 1]);
+}
+
+const privateOut = args.get("--private-out");
+const publicOut = args.get("--public-out");
+if (!privateOut || !publicOut) {
+  throw new Error("Usage: node scripts/generate_installer_release_key.mjs --private-out PATH --public-out PATH");
+}
+
+const { privateKey, publicKey } = generateKeyPairSync("ed25519", {
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+await Promise.all([
+  writeFile(privateOut, privateKey, { encoding: "utf8", mode: 0o600, flag: "wx" }),
+  writeFile(publicOut, publicKey, { encoding: "utf8", mode: 0o644, flag: "wx" }),
+]);
+

--- a/scripts/generate_installer_release_key.mjs
+++ b/scripts/generate_installer_release_key.mjs
@@ -21,4 +21,3 @@ await Promise.all([
   writeFile(privateOut, privateKey, { encoding: "utf8", mode: 0o600, flag: "wx" }),
   writeFile(publicOut, publicKey, { encoding: "utf8", mode: 0o644, flag: "wx" }),
 ]);
-

--- a/scripts/lib/installer-release.mjs
+++ b/scripts/lib/installer-release.mjs
@@ -1,0 +1,111 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const PACKAGE_SCHEMA = "aura-firmware-release-package-v1";
+export const SIGNATURE_SCHEMA = "aura-firmware-release-signature-v1";
+export const FLASH_SIZE_BYTES = 16 * 1024 * 1024;
+
+export function stableJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+    .join(",")}}`;
+}
+
+export function parseOffset(value) {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) return value;
+  if (typeof value !== "string" || !/^(?:0x[0-9a-f]+|\d+)$/i.test(value)) {
+    throw new Error(`Invalid flash offset: ${String(value)}`);
+  }
+  const parsed = value.toLowerCase().startsWith("0x")
+    ? Number.parseInt(value.slice(2), 16)
+    : Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid flash offset: ${value}`);
+  }
+  return parsed;
+}
+
+export function validateVersion(value) {
+  if (typeof value !== "string" || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(value)) {
+    throw new Error(`Invalid release version: ${String(value)}. Expected X.Y.Z.`);
+  }
+  return value;
+}
+
+export async function describeAsset({ directory, fileName, assetKind, flashOffset, modes }) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(fileName)) {
+    throw new Error(`Unsafe release file name: ${fileName}`);
+  }
+  const bytes = await readFile(join(directory, fileName));
+  return {
+    file_name: fileName,
+    asset_kind: assetKind,
+    flash_offset: parseOffset(flashOffset),
+    modes: [...modes].sort(),
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    size_bytes: bytes.byteLength,
+  };
+}
+
+export function signaturePayload(release) {
+  return {
+    schema: SIGNATURE_SCHEMA,
+    product_key: release.product_key,
+    version: release.version,
+    channel: release.channel,
+    hardware_target: release.hardware_target,
+    chip_family: release.chip_family,
+    modes: [...release.modes].sort(),
+    compatibility: release.compatibility,
+    provenance: release.provenance,
+    signature: {
+      algorithm: release.signature.algorithm,
+      key_id: release.signature.key_id,
+    },
+    assets: release.assets
+      .map((asset) => ({
+        file_name: asset.file_name,
+        flash_offset: asset.flash_offset,
+        modes: [...asset.modes].sort(),
+        sha256: asset.sha256,
+        size_bytes: asset.size_bytes,
+      }))
+      .sort(
+        (left, right) =>
+          left.flash_offset - right.flash_offset ||
+          left.file_name.localeCompare(right.file_name),
+      ),
+  };
+}
+
+export function signatureBytes(release) {
+  return Buffer.from(stableJson(signaturePayload(release)), "utf8");
+}
+
+export function validateFlashLayout(assets, modes, flashSize = FLASH_SIZE_BYTES) {
+  for (const mode of modes) {
+    const ranges = assets
+      .filter((asset) => asset.modes.includes(mode))
+      .map((asset) => ({
+        name: asset.file_name,
+        start: asset.flash_offset,
+        end: asset.flash_offset + asset.size_bytes,
+      }))
+      .sort((left, right) => left.start - right.start);
+
+    if (ranges.length === 0) throw new Error(`No binary parts are assigned to ${mode}.`);
+    for (let index = 0; index < ranges.length; index += 1) {
+      const range = ranges[index];
+      if (range.start < 0 || range.end > flashSize) {
+        throw new Error(`${range.name} does not fit the 16 MB flash layout.`);
+      }
+      if (index > 0 && range.start < ranges[index - 1].end) {
+        throw new Error(`${range.name} overlaps ${ranges[index - 1].name} in ${mode} mode.`);
+      }
+    }
+  }
+}

--- a/scripts/package_installer_release.mjs
+++ b/scripts/package_installer_release.mjs
@@ -1,0 +1,131 @@
+import { createPrivateKey, sign } from "node:crypto";
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import {
+  FLASH_SIZE_BYTES,
+  PACKAGE_SCHEMA,
+  describeAsset,
+  signatureBytes,
+  validateFlashLayout,
+  validateVersion,
+} from "./lib/installer-release.mjs";
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 2) {
+  args.set(process.argv[index], process.argv[index + 1]);
+}
+
+function required(name) {
+  const value = args.get(name)?.trim();
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+}
+
+const sourceDir = resolve(required("--source"));
+const stagingDir = resolve(required("--staging"));
+const version = validateVersion(required("--version"));
+const channel = required("--channel").toLowerCase();
+const commit = required("--commit");
+const keyId = required("--key-id");
+const privateKeyPath = resolve(required("--private-key"));
+const notesPath = args.get("--notes") ? resolve(args.get("--notes")) : null;
+
+if (!["stable", "beta", "recovery"].includes(channel)) {
+  throw new Error(`Unsupported release channel: ${channel}`);
+}
+if (!/^[a-f0-9]{40}$/i.test(commit)) throw new Error("Source commit must be a full Git SHA.");
+
+let sourceParts;
+let updateNames;
+if (channel === "recovery") {
+  sourceParts = [{ fileName: "recovery.bin", flashOffset: 0 }];
+  updateNames = new Set();
+} else {
+  const manifestFull = JSON.parse(await readFile(join(sourceDir, "manifest.json"), "utf8"));
+  const manifestUpdate = JSON.parse(
+    await readFile(join(sourceDir, "manifest-update.json"), "utf8"),
+  );
+  const fullParts = manifestFull?.builds?.[0]?.parts;
+  const updateParts = manifestUpdate?.builds?.[0]?.parts;
+  if (!Array.isArray(fullParts) || fullParts.length === 0) {
+    throw new Error("manifest.json does not contain a valid ESP32-S3 build.");
+  }
+  if (!Array.isArray(updateParts) || updateParts.length === 0) {
+    throw new Error("manifest-update.json does not contain an Update build.");
+  }
+  updateNames = new Set(updateParts.map((part) => basename(String(part.path))));
+  sourceParts = fullParts.map((part) => ({
+    fileName: basename(String(part.path)),
+    flashOffset: part.offset,
+  }));
+}
+const expectedNames =
+  channel === "recovery"
+    ? ["recovery.bin"]
+    : ["bootloader.bin", "partitions.bin", "boot_app0.bin", "firmware.bin", "littlefs.bin"];
+if (
+  sourceParts.length !== expectedNames.length ||
+  expectedNames.some((name) => !sourceParts.some((part) => part.fileName === name))
+) {
+  throw new Error(`The package must contain exactly: ${expectedNames.join(", ")}`);
+}
+
+const modes = channel === "recovery" ? ["recovery"] : ["full", "update"];
+const assets = [];
+for (const part of sourceParts) {
+  const assetModes =
+    channel === "recovery"
+      ? ["recovery"]
+      : ["full", ...(updateNames.has(part.fileName) ? ["update"] : [])];
+  assets.push(
+    await describeAsset({
+      directory: sourceDir,
+      fileName: part.fileName,
+      assetKind: part.fileName.replace(/\.bin$/i, "").replaceAll("-", "_"),
+      flashOffset: part.flashOffset,
+      modes: assetModes,
+    }),
+  );
+}
+validateFlashLayout(assets, modes);
+
+const release = {
+  schema: PACKAGE_SCHEMA,
+  product_key: "aura-aq",
+  version,
+  channel,
+  title: `Aura AQ ${version}`,
+  release_notes_file: notesPath ? "release-notes.md" : null,
+  hardware_target: "aura-aq-v1",
+  chip_family: "ESP32-S3",
+  modes,
+  compatibility: {
+    hardware_revision: "v1",
+    flash_size_bytes: FLASH_SIZE_BYTES,
+  },
+  provenance: {
+    build_id: commit.slice(0, 12),
+    commit,
+  },
+  signature: {
+    algorithm: "ed25519",
+    key_id: keyId,
+    value: "",
+  },
+  assets,
+};
+
+const privateKey = createPrivateKey(await readFile(privateKeyPath, "utf8"));
+if (privateKey.asymmetricKeyType !== "ed25519") {
+  throw new Error("The installer release key is not Ed25519.");
+}
+release.signature.value = sign(null, signatureBytes(release), privateKey).toString("base64");
+
+await mkdir(stagingDir, { recursive: false });
+for (const asset of assets) {
+  await copyFile(join(sourceDir, asset.file_name), join(stagingDir, asset.file_name));
+}
+if (notesPath) await copyFile(notesPath, join(stagingDir, "release-notes.md"));
+await writeFile(join(stagingDir, "release.json"), `${JSON.stringify(release, null, 2)}\n`, "utf8");
+
+process.stdout.write(JSON.stringify({ stagingDir, release }, null, 2));

--- a/scripts/prepare_installer_release.ps1
+++ b/scripts/prepare_installer_release.ps1
@@ -1,0 +1,122 @@
+param(
+  [string]$Env = "project_aura",
+  [Parameter(Mandatory = $true)][string]$Version,
+  [ValidateSet("stable", "beta", "recovery")][string]$Channel = "stable",
+  [string]$KeyDirectory = (Join-Path $env:USERPROFILE ".project_aura\signing"),
+  [string]$OutputRoot = "release-assets",
+  [string]$NodePath,
+  [string]$RecoveryBinary,
+  [switch]$SkipBuild,
+  [switch]$AllowDirty
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.Security
+
+$root = Resolve-Path (Join-Path $PSScriptRoot "..")
+$privatePath = Join-Path $KeyDirectory "installer-release-private-key.dpapi"
+$metadataPath = Join-Path $KeyDirectory "installer-release-key.json"
+$notesPath = Join-Path $root ("docs\releases\v{0}.md" -f $Version)
+$platformioIni = Join-Path $root "platformio.ini"
+$node = $NodePath
+if (-not $node) {
+  $node = (Get-Command node -ErrorAction SilentlyContinue).Source
+}
+if (-not $node) {
+  $node = Join-Path $env:ProgramFiles "nodejs\node.exe"
+}
+if (-not (Test-Path $node)) {
+  $node = Join-Path $env:USERPROFILE ".cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe"
+}
+if (-not (Test-Path $node)) {
+  throw "Node.js is required. Install Node.js or pass -NodePath <path-to-node.exe>."
+}
+
+Push-Location $root
+try {
+  if (-not $AllowDirty) {
+    $dirty = (& git status --porcelain).Trim()
+    if ($dirty) {
+      throw "Git working tree is dirty. Commit or stash changes before creating a signed release."
+    }
+  }
+  $commit = (& git rev-parse HEAD).Trim()
+  if ($LASTEXITCODE -ne 0 -or $commit -notmatch "^[a-f0-9]{40}$") {
+    throw "Could not resolve the source Git commit."
+  }
+} finally {
+  Pop-Location
+}
+
+if (-not (Test-Path $privatePath) -or -not (Test-Path $metadataPath)) {
+  throw "Installer release signing key is missing. Run scripts\create_installer_release_key.ps1 first."
+}
+if (-not (Test-Path $notesPath)) {
+  throw "Release notes are required: $notesPath"
+}
+
+if (Test-Path $platformioIni) {
+  $iniText = Get-Content -Raw -LiteralPath $platformioIni
+  $match = [regex]::Match($iniText, '-DAPP_VERSION=\\?"?([0-9A-Za-z._-]+)\\?"?')
+  if ($match.Success -and $match.Groups[1].Value -ne $Version) {
+    throw "Requested version $Version does not match platformio.ini version $($match.Groups[1].Value)."
+  }
+}
+
+$metadata = Get-Content -Raw -LiteralPath $metadataPath | ConvertFrom-Json
+$sourceDir = Join-Path $root (Join-Path $OutputRoot ("v" + $Version))
+$bundleName = "aura-aq-v{0}-{1}.aura-release.zip" -f $Version, $Channel
+$bundlePath = Join-Path $sourceDir $bundleName
+$stagingDir = Join-Path ([System.IO.Path]::GetTempPath()) ("aura-release-" + [guid]::NewGuid())
+$tempPrivate = Join-Path ([System.IO.Path]::GetTempPath()) ("aura-release-" + [guid]::NewGuid() + ".pem")
+
+try {
+  if ($Channel -eq "recovery") {
+    if (-not $RecoveryBinary -or -not (Test-Path -LiteralPath $RecoveryBinary)) {
+      throw "Recovery releases require -RecoveryBinary <path-to-signed-recovery.bin>."
+    }
+    New-Item -ItemType Directory -Force -Path $sourceDir | Out-Null
+    Copy-Item -Force -LiteralPath $RecoveryBinary -Destination (Join-Path $sourceDir "recovery.bin")
+  } else {
+    & powershell -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot "prepare_release_assets.ps1") `
+      -Env $Env -Version $Version -OutputRoot $OutputRoot -SkipWebInstallerSync -SkipBuild:$SkipBuild
+    if ($LASTEXITCODE -ne 0) {
+      throw "Firmware asset preparation failed."
+    }
+  }
+
+  $protected = [Convert]::FromBase64String((Get-Content -Raw -LiteralPath $privatePath).Trim())
+  $privateBytes = [System.Security.Cryptography.ProtectedData]::Unprotect(
+    $protected,
+    $null,
+    [System.Security.Cryptography.DataProtectionScope]::CurrentUser
+  )
+  [System.IO.File]::WriteAllBytes($tempPrivate, $privateBytes)
+
+  & $node (Join-Path $PSScriptRoot "package_installer_release.mjs") `
+    --source $sourceDir `
+    --staging $stagingDir `
+    --version $Version `
+    --channel $Channel `
+    --commit $commit `
+    --key-id $metadata.key_id `
+    --private-key $tempPrivate `
+    --notes $notesPath | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "Release package validation or signing failed."
+  }
+
+  if (Test-Path $bundlePath) {
+    throw "Release package already exists: $bundlePath"
+  }
+  Compress-Archive -Path (Join-Path $stagingDir "*") -DestinationPath $bundlePath -CompressionLevel Optimal
+  Write-Host ""
+  Write-Host "Signed Aura Admin package created:"
+  Write-Host $bundlePath
+  Write-Host ""
+  Write-Host "Upload this ZIP in Aura Admin -> Firmware & Installers."
+} finally {
+  Remove-Item -LiteralPath $tempPrivate -Force -ErrorAction SilentlyContinue
+  Remove-Item -LiteralPath $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/tests/installer-release-package.test.mjs
+++ b/scripts/tests/installer-release-package.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync, verify } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { signatureBytes } from "../lib/installer-release.mjs";
+
+const packageScript = fileURLToPath(
+  new URL("../package_installer_release.mjs", import.meta.url),
+);
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "aura-installer-package-"));
+  const source = join(root, "source");
+  const staging = join(root, "staging");
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const privateKeyPath = join(root, "private.pem");
+  await mkdir(source);
+  await writeFile(
+    privateKeyPath,
+    privateKey.export({ format: "pem", type: "pkcs8" }),
+  );
+  const parts = [
+    ["bootloader.bin", "0x0000"],
+    ["partitions.bin", "0x8000"],
+    ["boot_app0.bin", "0xE000"],
+    ["firmware.bin", "0x10000"],
+    ["littlefs.bin", "0xC90000"],
+  ];
+  for (let index = 0; index < parts.length; index += 1) {
+    await writeFile(join(source, parts[index][0]), Buffer.alloc(index + 2, index + 1));
+  }
+  await writeFile(join(source, "manifest.json"), JSON.stringify({
+    builds: [{ parts: parts.map(([path, offset]) => ({ path, offset })) }],
+  }));
+  await writeFile(join(source, "manifest-update.json"), JSON.stringify({
+    builds: [{ parts: [{ path: "firmware.bin", offset: "0x10000" }] }],
+  }));
+  const notes = join(root, "notes.md");
+  await writeFile(notes, "Release notes.");
+  return { root, source, staging, privateKeyPath, publicKey, notes };
+}
+
+test("package CLI prepares a verifiable signed Stable release directory", async () => {
+  const value = await fixture();
+  try {
+    const result = spawnSync(process.execPath, [
+      packageScript,
+      "--source", value.source,
+      "--staging", value.staging,
+      "--version", "1.1.6",
+      "--channel", "stable",
+      "--commit", "0123456789abcdef0123456789abcdef01234567",
+      "--key-id", "test-key",
+      "--private-key", value.privateKeyPath,
+      "--notes", value.notes,
+    ], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    const release = JSON.parse(
+      await readFile(join(value.staging, "release.json"), "utf8"),
+    );
+    assert.equal(release.assets.length, 5);
+    assert.deepEqual(release.modes, ["full", "update"]);
+    assert.equal(
+      verify(
+        null,
+        signatureBytes(release),
+        value.publicKey,
+        Buffer.from(release.signature.value, "base64"),
+      ),
+      true,
+    );
+
+    release.assets[0].sha256 = "0".repeat(64);
+    assert.equal(
+      verify(
+        null,
+        signatureBytes(release),
+        value.publicKey,
+        Buffer.from(release.signature.value, "base64"),
+      ),
+      false,
+    );
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("package CLI rejects a version with the wrong format", async () => {
+  const value = await fixture();
+  try {
+    const result = spawnSync(process.execPath, [
+      packageScript,
+      "--source", value.source,
+      "--staging", value.staging,
+      "--version", "v1.1.6",
+      "--channel", "stable",
+      "--commit", "0123456789abcdef0123456789abcdef01234567",
+      "--key-id", "test-key",
+      "--private-key", value.privateKeyPath,
+    ], { encoding: "utf8" });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Invalid release version/);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/installer-release.test.mjs
+++ b/scripts/tests/installer-release.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  FLASH_SIZE_BYTES,
+  signatureBytes,
+  stableJson,
+  validateFlashLayout,
+  validateVersion,
+} from "../lib/installer-release.mjs";
+
+test("stable JSON is independent of object insertion order", () => {
+  assert.equal(stableJson({ b: 2, a: 1 }), stableJson({ a: 1, b: 2 }));
+});
+
+test("signature payload is deterministic across asset order", () => {
+  const base = {
+    product_key: "aura-aq",
+    version: "1.1.6",
+    channel: "stable",
+    hardware_target: "aura-aq-v1",
+    chip_family: "ESP32-S3",
+    modes: ["full", "update"],
+    compatibility: { flash_size_bytes: FLASH_SIZE_BYTES },
+    provenance: { build_id: "abc", commit: "a".repeat(40) },
+    signature: { algorithm: "ed25519", key_id: "key", value: "" },
+  };
+  const a = { file_name: "firmware.bin", flash_offset: 0x10000, modes: ["update", "full"], sha256: "a".repeat(64), size_bytes: 100 };
+  const b = { file_name: "bootloader.bin", flash_offset: 0, modes: ["full"], sha256: "b".repeat(64), size_bytes: 10 };
+  assert.deepEqual(signatureBytes({ ...base, assets: [a, b] }), signatureBytes({ ...base, assets: [b, a] }));
+});
+
+test("invalid versions and overlapping layouts are rejected", () => {
+  assert.throws(() => validateVersion("v1.1.6"));
+  assert.throws(() =>
+    validateFlashLayout(
+      [
+        { file_name: "a.bin", flash_offset: 0, size_bytes: 10, modes: ["full"] },
+        { file_name: "b.bin", flash_offset: 5, size_bytes: 10, modes: ["full"] },
+      ],
+      ["full"],
+    ),
+  );
+});
+

--- a/scripts/tests/installer-release.test.mjs
+++ b/scripts/tests/installer-release.test.mjs
@@ -41,4 +41,3 @@ test("invalid versions and overlapping layouts are rejected", () => {
     ),
   );
 });
-


### PR DESCRIPTION
## Summary
- add one-command builder for signed `.aura-release.zip` packages
- package Full and Update assets with deterministic release metadata, offsets, sizes and SHA-256 hashes
- sign control-plane metadata with the local Ed25519 release key
- document key generation and release preparation

## Verification
- 5/5 release builder tests passed
- valid Stable package creation tested
- invalid version and overlapping flash layout rejected
- deterministic JSON/signature payload verified