### PR TITLE
fix(dashboard): show newest events instead of oldest in Dashboard Event Log

### DIFF
--- a/src/web/WebTemplatesDashboardAp.cpp
+++ b/src/web/WebTemplatesDashboardAp.cpp
@@ -1727,7 +1727,7 @@ function renderEvents(payload) {
   const uptimeS = isNum(payload && payload.uptime_s) ? payload.uptime_s : null;
   const severityClass = { warning:'sev-warning', danger:'sev-danger', critical:'sev-critical', info:'sev-info' };
 
-  const items = events.slice(0, 40).reverse().map(e => {
+  const items = events.slice(-40).reverse().map(e => {
     const sev = (e && typeof e.severity === 'string') ? e.severity : 'info';
     const sevClass = severityClass[sev] || 'sev-info';
     const tsMs = isNum(e && e.ts_ms) ? e.ts_ms : null;


### PR DESCRIPTION
Encountered when troubleshooting #151 (did self-recover, but discovered this quirk+ one nice to have [nice to have submitting separately] contributing here)

/api/events (hence the dashboard UI) provides entries oldest-first, so slice(0, 40) kept the oldest 40 of the 48-entry window and hid the newest lines whenever more than 40 filtered events were pending (e.g. right after a chatty boot). Quick modification to use slice(-40) keeping the newest 40 before reversing for view.

## Summary
Very small modification to pull last 40 of event log instead of 0,40 resulting in oldest boot appearing when hitting the page. Separate PR inbound for a different improvement

## Checklist
- [x] I understand that this PR cannot be merged until every contributor completes the CLA check.
- [x] I disclosed any third-party material and employer or organisation rights affecting this PR.
- [x] I tested my changes or explained why tests are not applicable.
- [x] I updated documentation if needed.

## CLA Confirmation
I have read and agree to the Project Aura Individual Contributor License Agreement v2.0, and I hereby sign it.
